### PR TITLE
Fix/install cypress dependencies in dev docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM debian
 SHELL ["/bin/bash", "--login", "-c"]
 
 RUN apt update && \
-    apt install -y sudo curl tmux
+    apt install -y sudo curl tmux && \
+    apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
 # Setup user
 RUN useradd -ms /bin/bash a && \
@@ -21,7 +22,8 @@ RUN sudo apt install -y python3 python3-pip && \
 COPY --chown=a static/.nvmrc .nvmrc
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
 RUN nvm install && \
-    nvm use
+    nvm use && \
+    npm install -g cypress@9.5.2
 
 # Create directories
 RUN mkdir /home/a/annoto && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,5 @@ COPY --chown=a /entrypoint.sh entrypoint.sh
 
 EXPOSE 5000
 EXPOSE 3000
+EXPOSE 5050
 ENTRYPOINT "./entrypoint.sh"


### PR DESCRIPTION
Makes it possible to use `npm run test:unit:ci` / `npm run test:e2e:ci` in the dev docker container