### PR TITLE
Fix development config

### DIFF
--- a/api/.env.dev
+++ b/api/.env.dev
@@ -1,1 +1,0 @@
-engine_connect_args = {"check_same_thread": False}

--- a/api/.env.development
+++ b/api/.env.development
@@ -1,0 +1,1 @@
+engine_connect_args = {"check_same_thread": false}


### PR DESCRIPTION
Which lead to the well-known error
```
SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 139682474104640 and this is thread id 139682407204608.           
```