### PR TITLE
Fix/test utils camel case

### DIFF
--- a/static/cypress/integration/app.spec.ts
+++ b/static/cypress/integration/app.spec.ts
@@ -1,4 +1,4 @@
-import { login, setup_intercepts } from "./utils";
+import { login, setupIntercepts } from "./utils";
 
 describe("Application", () => {
   it("visits the app root url", () => {
@@ -8,11 +8,11 @@ describe("Application", () => {
     cy.visit("/").get("#logout-button").should("not.exist");
   });
   it("shows a logout button when the user is logged in", () => {
-    setup_intercepts();
+    setupIntercepts();
     login().get("#logout-button");
   });
   it("Logout button redirects to login page", () => {
-    setup_intercepts();
+    setupIntercepts();
     login().get("#logout-button").click({ force: true }).get("#login-view");
   });
 });

--- a/static/cypress/integration/login_view.spec.ts
+++ b/static/cypress/integration/login_view.spec.ts
@@ -1,8 +1,8 @@
-import { intercept_login_with_failure, login, setup_intercepts } from "./utils";
+import { interceptLoginWithFailure, login, setupIntercepts } from "./utils";
 
 describe("LoginView", () => {
   it("logs the user in when valid login data is provided", () => {
-    setup_intercepts();
+    setupIntercepts();
     login().get("#tasks-overview");
   });
 
@@ -11,7 +11,7 @@ describe("LoginView", () => {
   });
 
   it("errors if invalid login data provided", () => {
-    setup_intercepts({ intercept_login: intercept_login_with_failure });
+    setupIntercepts({ interceptLogin: interceptLoginWithFailure });
     login().get("div.alert.-danger");
   });
 });

--- a/static/cypress/integration/task_view.spec.ts
+++ b/static/cypress/integration/task_view.spec.ts
@@ -1,14 +1,14 @@
 import {
   openTask,
-  intercept_next_image_with_failure,
+  interceptNextImageWithFailure,
   login,
-  proof_condition,
-  setup_intercepts,
+  proofCondition,
+  setupIntercepts,
 } from "./utils";
 
 describe("TaskView", () => {
   it("shows full name", () => {
-    setup_intercepts();
+    setupIntercepts();
     login()
       .wait("@get_tasks")
       .then(() => openTask("ecg-qrs-classification-physiodb"))
@@ -17,7 +17,7 @@ describe("TaskView", () => {
   });
 
   it("shows the proof of condition popup on startup", () => {
-    setup_intercepts();
+    setupIntercepts();
     login()
       .wait("@get_tasks")
       .then(() => openTask("ecg-qrs-classification-physiodb"))
@@ -26,17 +26,17 @@ describe("TaskView", () => {
   });
 
   it("can close the proof of condition dialog when checkbox is checked", () => {
-    setup_intercepts();
+    setupIntercepts();
     login()
       .wait("@get_tasks")
       .then(() => openTask("ecg-qrs-classification-physiodb"))
-      .then(proof_condition)
+      .then(proofCondition)
       .get("#proof-of-condition")
       .should("not.be.visible");
   });
 
   it("cannot close the proof of condition dialog when checkbox is not checked", () => {
-    setup_intercepts();
+    setupIntercepts();
     login()
       .wait("@get_tasks")
       .then(() => openTask("ecg-qrs-classification-physiodb"))
@@ -47,8 +47,8 @@ describe("TaskView", () => {
   });
 
   it("informs the user when no more images are available for annotation", () => {
-    setup_intercepts({
-      intercept_next_image: intercept_next_image_with_failure,
+    setupIntercepts({
+      interceptNextImage: interceptNextImageWithFailure,
     });
     login()
       .wait("@get_tasks")
@@ -59,7 +59,7 @@ describe("TaskView", () => {
   });
 
   it("shows annotation buttons", () => {
-    setup_intercepts();
+    setupIntercepts();
     login()
       .wait("@get_tasks")
       .then(() => openTask("ecg-qrs-classification-physiodb"))
@@ -71,7 +71,7 @@ describe("TaskView", () => {
   });
 
   it("shows image display", () => {
-    setup_intercepts();
+    setupIntercepts();
     login()
       .wait("@get_tasks")
       .then(() => openTask("ecg-qrs-classification-physiodb"))
@@ -81,11 +81,11 @@ describe("TaskView", () => {
   });
 
   it("annotation button stores annotation", () => {
-    setup_intercepts();
+    setupIntercepts();
     login()
       .wait("@get_tasks")
       .then(() => openTask("ecg-qrs-classification-physiodb"))
-      .then(proof_condition)
+      .then(proofCondition)
       .wait("@get_next_image")
       .get("#annotation-button-atrial-fibrillation")
       .click()
@@ -97,7 +97,7 @@ describe("TaskView", () => {
 
   it("annotation request includes condition from popup", () => {
     cy.on("uncaught:exception", () => false);
-    setup_intercepts();
+    setupIntercepts();
     login()
       .wait("@get_tasks")
       .then(() => openTask("ecg-qrs-classification-physiodb"))
@@ -111,11 +111,11 @@ describe("TaskView", () => {
   });
 
   it("shows next image once annotation has been made", () => {
-    setup_intercepts();
+    setupIntercepts();
     login()
       .wait("@get_tasks")
       .then(() => openTask("ecg-qrs-classification-physiodb"))
-      .then(proof_condition)
+      .then(proofCondition)
       .wait("@get_next_image")
       .get("#annotation-button-atrial-fibrillation")
       .click()

--- a/static/cypress/integration/tasks_overview.spec.ts
+++ b/static/cypress/integration/tasks_overview.spec.ts
@@ -1,30 +1,30 @@
 import {
   openTask,
-  intercept_get_tasks_with_empty_list,
+  interceptGetTasksWithEmptyList,
   login,
-  setup_intercepts,
+  setupIntercepts,
 } from "./utils";
 
 describe("TasksOverView", () => {
   it("shows full name", () => {
-    setup_intercepts();
+    setupIntercepts();
     login().get("#userLabel").contains("Prof. Dr. Folivora");
   });
 
   it("shows cards for tasks", () => {
-    setup_intercepts();
+    setupIntercepts();
     login().get(".card#task-ecg-qrs-classification-physiodb");
   });
 
   it("informs the user when there are no tasks", () => {
-    setup_intercepts({
-      intercept_get_tasks: intercept_get_tasks_with_empty_list,
+    setupIntercepts({
+      interceptGetTasks: interceptGetTasksWithEmptyList,
     });
     login().get("#no-more-tasks");
   });
 
   it("shows the task view when a task was selected", () => {
-    setup_intercepts();
+    setupIntercepts();
     login()
       .then(() => openTask("ecg-qrs-classification-physiodb"))
       .get("#task-view");

--- a/static/cypress/integration/utils.ts
+++ b/static/cypress/integration/utils.ts
@@ -1,7 +1,7 @@
 import type { Method } from "axios";
 import type { CyHttpMessages, RouteMatcher } from "cypress/types/net-stubbing";
 
-function intercept_with_spy(
+function interceptWithSpy(
   method: Method,
   url: RouteMatcher,
   response: object,
@@ -23,7 +23,7 @@ function intercept_with_spy(
   ).as(name);
 }
 
-export function intercept_get_task() {
+export function interceptGetTask() {
   cy.intercept(
     "GET",
     `${Cypress.env("API_URL")}/tasks/ecg-qrs-classification-physiodb`,
@@ -31,19 +31,19 @@ export function intercept_get_task() {
   ).as("get_task");
 }
 
-export function intercept_get_tasks() {
+export function interceptGetTasks() {
   cy.intercept("GET", `${Cypress.env("API_URL")}/tasks`, {
     fixture: "tasks.json",
   }).as("get_tasks");
 }
 
-export function intercept_get_tasks_with_empty_list() {
+export function interceptGetTasksWithEmptyList() {
   cy.intercept("GET", `${Cypress.env("API_URL")}/tasks`, {
     fixture: "tasks_empty.json",
   }).as("get_tasks");
 }
 
-export function intercept_next_image() {
+export function interceptNextImage() {
   cy.intercept(
     "GET",
     `${Cypress.env("API_URL")}/tasks/ecg-qrs-classification-physiodb/next`,
@@ -53,7 +53,7 @@ export function intercept_next_image() {
   ).as("get_next_image");
 }
 
-export function intercept_next_image_with_failure() {
+export function interceptNextImageWithFailure() {
   cy.intercept(
     "GET",
     `${Cypress.env("API_URL")}/tasks/ecg-qrs-classification-physiodb/next`,
@@ -61,8 +61,8 @@ export function intercept_next_image_with_failure() {
   ).as("get_next_image");
 }
 
-export function intercept_store_annotation() {
-  intercept_with_spy(
+export function interceptStoreAnnotation() {
+  interceptWithSpy(
     "POST",
     `${Cypress.env("API_URL")}/tasks/ecg-qrs-classification-physiodb/sloth.jpg`,
     { statusCode: 204 },
@@ -70,7 +70,7 @@ export function intercept_store_annotation() {
   );
 }
 
-export function intercept_get_image() {
+export function interceptGetImage() {
   cy.intercept(
     "GET",
     `${Cypress.env("API_URL")}/tasks/ecg-qrs-classification-physiodb/sloth.jpg`,
@@ -78,46 +78,46 @@ export function intercept_get_image() {
   ).as("get_image");
 }
 
-export function intercept_login() {
+export function interceptLogin() {
   cy.intercept("POST", `${Cypress.env("API_URL")}/login`, {
     fixture: "login.json",
   }).as("login");
 }
 
-export function intercept_ping() {
+export function interceptPing() {
   cy.intercept("GET", `${Cypress.env("API_URL")}/ping`, {
     statusCode: 204,
   }).as("ping");
 }
 
-export function intercept_login_with_failure() {
+export function interceptLoginWithFailure() {
   cy.intercept("POST", `${Cypress.env("API_URL")}/login`, {
     statusCode: 401,
   }).as("login");
 }
 
 export interface InterceptConfig {
-  intercept_login?: () => void;
-  intercept_ping?: () => void;
-  intercept_get_task?: () => void;
-  intercept_get_tasks?: () => void;
-  intercept_next_image?: () => void;
-  intercept_get_image?: () => void;
-  intercept_store_annotation?: () => void;
+  interceptLogin?: () => void;
+  interceptPing?: () => void;
+  interceptGetTask?: () => void;
+  interceptGetTasks?: () => void;
+  interceptNextImage?: () => void;
+  interceptGetImage?: () => void;
+  interceptStoreAnnotation?: () => void;
 }
 
 // Make sure that every key of IntercepyConfig will be filled with a default in this object.
 const defaultInterceptConfig: InterceptConfig = {
-  intercept_login: intercept_login,
-  intercept_ping: intercept_ping,
-  intercept_get_task: intercept_get_task,
-  intercept_get_tasks: intercept_get_tasks,
-  intercept_next_image: intercept_next_image,
-  intercept_get_image: intercept_get_image,
-  intercept_store_annotation: intercept_store_annotation,
+  interceptLogin: interceptLogin,
+  interceptPing: interceptPing,
+  interceptGetTask: interceptGetTask,
+  interceptGetTasks: interceptGetTasks,
+  interceptNextImage: interceptNextImage,
+  interceptGetImage: interceptGetImage,
+  interceptStoreAnnotation: interceptStoreAnnotation,
 };
 
-export function setup_intercepts(config: InterceptConfig = {}) {
+export function setupIntercepts(config: InterceptConfig = {}) {
   const interceptConfig: { [key: string]: () => void } = {
     ...defaultInterceptConfig,
     ...config,
@@ -143,7 +143,7 @@ export function openTask(task_id: string) {
   return cy.visit("/").get(`.card#task-${task_id} button`).click();
 }
 
-export function proof_condition() {
+export function proofCondition() {
   return cy
     .get("#proof-of-condition .checkbox-label")
     .click()


### PR DESCRIPTION
### Changes made by this Pull Request

- The e2e test util functions had their names in pythonic underscore case (or what that is called) and for javascript I think camelCase is the convention (the cypress api also uses camelCase), so I thought it would fit to change that

#119 has to be merged first (sorry for not squashing)